### PR TITLE
Display hours/minutes label tooltip

### DIFF
--- a/src/Components/Content/Content.js
+++ b/src/Components/Content/Content.js
@@ -45,7 +45,7 @@ export default class Content extends React.Component {
       "timeMovies": this.getDisplayedTime(data.runtimes.movies),
       "genres": {
         "genreList": data.genres.slice(0, sizeList).map(genre => genre.genre),
-        "runtimeList": data.genres.slice(0, sizeList).map(genre => genre.runtime),
+        "runtimeList": data.genres.slice(0, sizeList).map(genre => Math.trunc(genre.runtime)),
       },
       "movies": {
         "movieList": data.movies.slice(0, sizeList).map(movie => movie.title),
@@ -72,11 +72,9 @@ export default class Content extends React.Component {
   }
 
   updateData = (data) => {
-    console.log(JSON.stringify(data));
     Processor.process(data)
     .then(res => {
       this.setState({stats: this.getFormatedData(res)});
-      console.log(JSON.stringify(this.getFormatedData(res)));
     });
   };
 

--- a/src/Components/StatsPage/BarChart/BarChart.js
+++ b/src/Components/StatsPage/BarChart/BarChart.js
@@ -2,10 +2,27 @@ import React from "react";
 import { Bar } from 'react-chartjs-2';
 
 export default class BarChart extends React.Component {
-  render() {
-    // you only have to set those values thanks to this.props
+  needToConvertToHours = () => {
+    var i = 0;
+    while (i < this.props.data.values.length) {
+      if(this.props.data.values[i] > 120) return true;
+      i++;
+    }
 
-    const data = {
+    return false;
+  }
+  
+  componentDidMount() {
+    if (this.needToConvertToHours()) {
+      this.props.data.values = this.props.data.values.map(value => Math.trunc(value / 60));
+      this.forceUpdate();
+    }
+  }
+
+  render() {
+    const self = this;
+
+    var data = {
       labels: this.props.data.labels,
       datasets: [{
         backgroundColor: 'rgba(255,255,255)',
@@ -52,13 +69,24 @@ export default class BarChart extends React.Component {
         }]
       },
 
-      maintainAspectRatio: true
+      maintainAspectRatio: true,
+
+      tooltips: {
+        enabled: true,
+        mode: 'single',
+        callbacks: {
+          label: function(tooltipItems, data) { 
+            const suffix = self.needToConvertToHours() ? ' h' : ' min';
+              return tooltipItems.yLabel + suffix;
+          }
+        }
+      },
     };
 
     return (
       <div className="chart stats--bar-chart">
         <div className="stats--title">{this.props.title}</div>
-        <div className="stats--legend-bar">Minutes</div>
+        <div className="stats--legend-bar">{this.needToConvertToHours() ? "Hours" : "Minutes"}</div>
         <Bar
           data={data}
           options={options}

--- a/src/Components/StatsPage/PieChart/PieChart.js
+++ b/src/Components/StatsPage/PieChart/PieChart.js
@@ -2,21 +2,60 @@ import React from "react";
 import { Pie } from 'react-chartjs-2';
 
 export default class PieChart extends React.Component {
+	constructor() {
+		super();
+		this.state = {expressedInHours: false}
+	}
+	needToConvertToHours = () => {
+		if(this.state.expressedInHours) return true;
+
+		var i = 0;
+		while (i < this.props.data.values.length) {
+			if(this.props.data.values[i] > 120) {
+				this.setState({expressedInHours: true});
+				return true;
+			}
+			i++;
+		}
+
+		return false;
+	}
+		
+	componentDidMount() {
+		if (this.needToConvertToHours()) {
+			this.props.data.values = this.props.data.values.map(value => Math.trunc(value / 60));
+			this.forceUpdate();
+		}
+	}
+
   render() {
     const data = {
-			labels: this.props.data.labels,
-			datasets: [{
-				data: this.props.data.values,
-				backgroundColor: "#7C87D7",
-				hoverBackgroundColor: "#FF786B"
-			}]
-		};
-		
-		const options = {
-			legend: {
-				display: false
+		labels: this.props.data.labels,
+		datasets: [{
+			data: this.props.data.values,
+			backgroundColor: "#7C87D7",
+			hoverBackgroundColor: "#FF786B"
+		}]
+	};
+
+	const self = this;
+
+	const options = {
+		legend: {
+			display: false
+		},
+		tooltips: {
+			enabled: true,
+			mode: 'single',
+			callbacks: {
+				label: function(tooltipItem, data) { 
+					var indice = tooltipItem.index;
+					const suffix = self.state.expressedInHours ? ' h' : ' min';
+					return data.datasets[0].data[indice] + suffix;
+				}
 			}
-		};
+		},
+	};
 
     return (
       <div>

--- a/src/Components/StatsPage/StatsPage.js
+++ b/src/Components/StatsPage/StatsPage.js
@@ -28,7 +28,7 @@ export default class StatsPage extends React.Component {
     };
 
     const statsWeekly = {
-      labels: ['L', 'M', 'M', 'J', 'V', 'S', 'D'],
+      labels: ['M', 'T', 'W', 'T', 'F', 'S', 'S'],
       values: this.props.stats.weekly.meanByDay
     };
 


### PR DESCRIPTION
On bar + pie charts, convert values to hours if minutes > 120
Update tooltip label when hoover